### PR TITLE
GH Actions Workflow for Auto-deployment to Production

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,25 @@
+name: deploy
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+      - run: pnpm install
+      - run: pnpm run build
+      - uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          source: "package.json,pnpm-lock.yaml"
+          target: ${{ SECRETS.DEPLOY_PATH }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow, `deploy`, that automatically installs, builds and deploys build artifacts to a production server defined in the repository's secrets key-value store.

In its current state it builds the output artifacts, but only deploys the npm dependency files as an initial test of the script.